### PR TITLE
Implement observing of willChangeFrame and didChangeFrame notifications (WIP)

### DIFF
--- a/Example/KeyboardWrapper/ViewController.swift
+++ b/Example/KeyboardWrapper/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        keyboardWrapper = KeyboardWrapper(delegate: self)
+        keyboardWrapper = KeyboardWrapper(delegate: self, observableKeyboardStates: [.willShow, .willHide])
     }
 
     @IBAction func tapGestureRecognizerAction(_ sender: UIGestureRecognizer) {

--- a/Example/Tests/KeyboardWrapperTests.swift
+++ b/Example/Tests/KeyboardWrapperTests.swift
@@ -21,6 +21,8 @@ class KeyboardWrapperTests: XCTestCase {
         let notificationNames = [
             NSNotification.Name.UIKeyboardWillShow,
             NSNotification.Name.UIKeyboardDidShow,
+            NSNotification.Name.UIKeyboardWillChangeFrame,
+            NSNotification.Name.UIKeyboardDidChangeFrame,
             NSNotification.Name.UIKeyboardWillHide,
             NSNotification.Name.UIKeyboardDidHide
         ]
@@ -29,7 +31,7 @@ class KeyboardWrapperTests: XCTestCase {
             NotificationCenter.default.post(name: name, object: nil)
         }
 
-        XCTAssertEqual(keyboardWrapperDelegate.states, [.willShow, .visible, .willHide, .hidden])
+        XCTAssertEqual(keyboardWrapperDelegate.states, [.willShow, .visible, .willChangeFrame, .didChangeFrame, .willHide, .hidden])
     }
     
 }

--- a/Example/Tests/KeyboardWrapperTests.swift
+++ b/Example/Tests/KeyboardWrapperTests.swift
@@ -5,19 +5,21 @@ import KeyboardWrapper
 class KeyboardWrapperTests: XCTestCase {
 
     let keyboardWrapperDelegate = Delegate()
-    var keyboardWrapper: KeyboardWrapper?
 
     override func setUp() {
         super.setUp()
-        keyboardWrapper = KeyboardWrapper(delegate: keyboardWrapperDelegate)
+        keyboardWrapperDelegate.states = []
     }
 
     override func tearDown() {
         super.tearDown()
-        keyboardWrapper = nil
     }
 
-    func testKeyboardStates() {
+    func testAllKeyboardStates() {
+        let allStates: [KeyboardState] = [.willShow, .visible, .willChangeFrame, .didChangeFrame, .willHide, .hidden]
+        let keyboardWrapper = KeyboardWrapper(delegate: keyboardWrapperDelegate, observableKeyboardStates: allStates)
+        XCTAssertEqual(keyboardWrapper.observableKeyboardStates, allStates)
+
         let notificationNames = [
             NSNotification.Name.UIKeyboardWillShow,
             NSNotification.Name.UIKeyboardDidShow,
@@ -33,7 +35,46 @@ class KeyboardWrapperTests: XCTestCase {
 
         XCTAssertEqual(keyboardWrapperDelegate.states, [.willShow, .visible, .willChangeFrame, .didChangeFrame, .willHide, .hidden])
     }
-    
+
+    func testSomeKeyboardStates() {
+        let someStates: [KeyboardState] = [.willChangeFrame, .willHide]
+        let keyboardWrapper = KeyboardWrapper(delegate: keyboardWrapperDelegate, observableKeyboardStates: someStates)
+        XCTAssertEqual(keyboardWrapper.observableKeyboardStates, someStates)
+
+        let notificationNames = [
+            NSNotification.Name.UIKeyboardWillShow,
+            NSNotification.Name.UIKeyboardDidShow,
+            NSNotification.Name.UIKeyboardWillChangeFrame,
+            NSNotification.Name.UIKeyboardDidChangeFrame,
+            NSNotification.Name.UIKeyboardWillHide,
+            NSNotification.Name.UIKeyboardDidHide
+        ]
+
+        for name in notificationNames {
+            NotificationCenter.default.post(name: name, object: nil)
+        }
+
+        XCTAssertEqual(keyboardWrapperDelegate.states, [.willChangeFrame, .willHide])
+    }
+
+    func testOrderOfSomeKeyboardStates() {
+        let someStates: [KeyboardState] = [.willChangeFrame, .willHide]
+        let keyboardWrapper = KeyboardWrapper(delegate: keyboardWrapperDelegate, observableKeyboardStates: someStates)
+        XCTAssertEqual(keyboardWrapper.observableKeyboardStates, someStates)
+
+        let notificationNames = [
+            NSNotification.Name.UIKeyboardWillShow,
+            NSNotification.Name.UIKeyboardDidShow,
+            NSNotification.Name.UIKeyboardWillHide,
+            NSNotification.Name.UIKeyboardWillChangeFrame,
+        ]
+
+        for name in notificationNames {
+            NotificationCenter.default.post(name: name, object: nil)
+        }
+
+        XCTAssertEqual(keyboardWrapperDelegate.states, [.willHide, .willChangeFrame])
+    }
 }
 
 class Delegate: KeyboardWrapperDelegate {

--- a/Pod/Classes/KeyboardWrapper.swift
+++ b/Pod/Classes/KeyboardWrapper.swift
@@ -11,22 +11,24 @@ public protocol KeyboardWrapperDelegate: class {
 /// Responsible for observing `UIKeyboard` notifications and calling `delegate` to notify about changes.
 open class KeyboardWrapper {
 
+    public let observableKeyboardStates: [KeyboardState]
+
     /// The delegate for keyboard notifications.
     open weak var delegate: KeyboardWrapperDelegate?
 
     /// Creates a new instance of `KeyboardWrapper` and adds itself as observer for `UIKeyboard` notifications.
-    public init() {
+    public init(observableKeyboardStates: [KeyboardState]) {
+        self.observableKeyboardStates = observableKeyboardStates
         let center = NotificationCenter.default
-        let states: [KeyboardState] = [.hidden, .willShow, .visible, .willHide, .willChangeFrame, .didChangeFrame ]
-        for state in states {
+        for state in observableKeyboardStates {
             center.addObserver(self, selector: #selector(keyboardNotification(_:)), name: state.notificationName, object: nil)
         }
     }
 
     /// Creates a new instance of `KeyboardWrapper`, adds itself as observer for `UIKeyboard` notifications and
     /// sets `delegate`.
-    public convenience init(delegate: KeyboardWrapperDelegate) {
-        self.init()
+    public convenience init(delegate: KeyboardWrapperDelegate, observableKeyboardStates: [KeyboardState]) {
+        self.init(observableKeyboardStates: observableKeyboardStates)
         self.delegate = delegate
     }
 

--- a/Pod/Classes/KeyboardWrapper.swift
+++ b/Pod/Classes/KeyboardWrapper.swift
@@ -19,6 +19,8 @@ open class KeyboardWrapper {
         let center = NotificationCenter.default
         center.addObserver(self, selector: #selector(keyboardWillShowNotification), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         center.addObserver(self, selector: #selector(keyboardDidShowNotification), name: NSNotification.Name.UIKeyboardDidShow, object: nil)
+        center.addObserver(self, selector: #selector(keyboardWillChangeFrameNotification), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
+        center.addObserver(self, selector: #selector(keyboardDidChangeFrameNotification), name: NSNotification.Name.UIKeyboardDidChangeFrame, object: nil)
         center.addObserver(self, selector: #selector(keyboardWillHideNotification), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         center.addObserver(self, selector: #selector(keyboardDidHideNotification), name: NSNotification.Name.UIKeyboardDidHide, object: nil)
     }
@@ -41,6 +43,16 @@ open class KeyboardWrapper {
 
     @objc private func keyboardDidShowNotification(_ notification: Notification) {
         let info = KeyboardInfo(info: notification.userInfo, state: .visible)
+        delegate?.keyboardWrapper(self, didChangeKeyboardInfo: info)
+    }
+
+    @objc private func keyboardWillChangeFrameNotification(_ notification: Notification) {
+        let info = KeyboardInfo(info: notification.userInfo, state: .willChangeFrame)
+        delegate?.keyboardWrapper(self, didChangeKeyboardInfo: info)
+    }
+
+    @objc private func keyboardDidChangeFrameNotification(_ notification: Notification) {
+        let info = KeyboardInfo(info: notification.userInfo, state: .didChangeFrame)
         delegate?.keyboardWrapper(self, didChangeKeyboardInfo: info)
     }
 
@@ -73,6 +85,14 @@ public enum KeyboardState {
     /// Denotes state when the keyboard about to hide.
     /// Corresponds to `UIKeyboardWillHideNotification`.
     case willHide
+
+    /// Denotes state when the keyboard about to change its frame.
+    /// Corresponds to `UIKeyboardWillChangeFrameNotification`.
+    case willChangeFrame
+
+    /// Denotes state when the keyboard changed its frame.
+    /// Corresponds to `UIKeyboardDidChangeFrameNotification`.
+    case didChangeFrame
 }
 
 /// Represents info about keyboard extracted from `NSNotification`.

--- a/Pod/Classes/KeyboardWrapper.swift
+++ b/Pod/Classes/KeyboardWrapper.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Implement the method of this protocol to respond to `UIKeyboard` notifications.
 public protocol KeyboardWrapperDelegate: class {
 
-    /// Called when `KeyboardWrapper` will receive `UIKeyboard[WillShow|DidShow|WillHide|DidHide]Notification`.
+    /// Called when `KeyboardWrapper` will receive `UIKeyboard` notifications observed by `KeyboardWrapper`.
     func keyboardWrapper(_ wrapper: KeyboardWrapper, didChangeKeyboardInfo info: KeyboardInfo)
 }
 
@@ -72,7 +72,7 @@ public enum KeyboardState {
     case didChangeFrame
 
     /// A name of a notification that corresponds to this keyboard state.
-    var notificationName: NSNotification.Name {
+    var notificationName: Notification.Name {
         switch self {
         case .hidden: return .UIKeyboardDidHide
         case .willShow: return .UIKeyboardWillShow
@@ -98,7 +98,7 @@ public enum KeyboardState {
     }
 }
 
-/// Represents info about keyboard extracted from `NSNotification`.
+/// Represents info about keyboard extracted from `Notification`.
 public struct KeyboardInfo {
 
     /// The state of the keyboard.
@@ -132,7 +132,7 @@ public struct KeyboardInfo {
 }
 
 public extension KeyboardInfo {
-    /// Creates instance of `KeyboardInfo` using `userInfo` from `NSNotification` object and a keyboard state.
+    /// Creates instance of `KeyboardInfo` using `userInfo` from `Notification` object and a keyboard state.
     /// If there is no info or `info` doesn't contain appropriate key-value pair uses default values.
     init(info: [AnyHashable: Any]?, state: KeyboardState) {
         self.state = state


### PR DESCRIPTION
Previously `KeyboardWrapper` was observing only four keyboard notifications: `willShow`, `didShow`, `willHide`, `didHide`. Now here additional two: `willChangeFrame` and `didChangeFram`.

Also there is a **breaking change**: `KeyboardWrapper` requires additional init parameter – `observableKeyboardStates`, i.e. notifications that will be observed. The motivation behind this is that not all need to observe all six keyboard notifications.